### PR TITLE
Security fix for github.com/miekg/dns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/mattn/go-shellwords v1.0.6 // indirect
-	github.com/miekg/dns v1.1.16
+	github.com/miekg/dns v1.1.25
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c // indirect
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect


### PR DESCRIPTION
github.com/miekg/dns is vulnerable. Please see the details here and update to more secured one 

https://search.gocenter.io/github.com~2Fmiekg~2Fdns/info?version=v1.1.16